### PR TITLE
Rotation and friction improvements

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -351,6 +351,7 @@ playGame.prototype = {
         //player collides with gears and start pad
         player.body.setCategoryContactCallback(2, helper.gearCallback, this);
         player.body.setCategoryContactCallback(3, helper.startPadContactCallback, this);
+        player.body.friction = 1;
 
         cursors = game.input.keyboard.createCursorKeys();
     },

--- a/src/levelChanger.js
+++ b/src/levelChanger.js
@@ -58,6 +58,7 @@ var LevelChanger = function(game){
         planetGroup.add(planet);
         game.physics.box2d.enable(planet);
         planet.body.static = true;
+        planet.body.friction = 1;
 
         planet.body.setCircle(planet.width / 2);
         gravityGraphics.drawCircle(planet.x, planet.y, planet.width + planet.gravityRadius);


### PR DESCRIPTION
This PR fixes planet/player friction, and (arguably) improves the behavior of the player and camera rotation as the player moves through the gravity field and “up” changes.

It turns out the reason box2d’s friction wasn’t working was that the player rotation logic directly modified the orientation of the player’s physics body, and doing that interferes with box2d’d friction logic. (It is often the case that directly change the position and orientation of objects prevents physics engines from working properly.)

This PR changes the player’s rotation by altering the angular velocity instead. In the process, I also tidied up the camera rotation logic. The resulting behavior is smoother than before, since the player and camera _ease into_ the new “up” instead of being locked to it.

This may or may not be a good thing; if it’s _too smooth_ for your taste now, there are some new parameters in the code you can play with. Interesting things also happen if you move the params to be even smoother — especially the camera. It creates a floating feeling that's perhaps a bit more "spacey" feeling, but also a bit less tight. I encourage you to mess with it and see if you like it.